### PR TITLE
fix: prevent duplicate scheduled clockins and repair Bark notifications

### DIFF
--- a/internal/core/service_test.go
+++ b/internal/core/service_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -33,14 +34,21 @@ func TestExtractCampaignID(t *testing.T) {
 }
 
 func TestNewServiceLoadsConfig(t *testing.T) {
-	service, err := NewService(filepath.Join("..", "..", "config.json"), "")
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.json")
+	configJSON := `{"cookie_file_path":"cookie.json","target_url":"https://f.kdocs.cn/g/MmHrjlBS#routePrompt","input_name":"测试用户"}`
+	if err := os.WriteFile(configPath, []byte(configJSON), 0o600); err != nil {
+		t.Fatalf("写入测试配置失败: %v", err)
+	}
+
+	service, err := NewService(configPath, "")
 	if err != nil {
 		t.Fatalf("加载服务失败: %v", err)
 	}
 	if service.Config.TargetURL == "" {
 		t.Fatal("TargetURL 不应为空")
 	}
-	if service.CookiePath == "" {
-		t.Fatal("CookiePath 不应为空")
+	if service.CookiePath != filepath.Join(dir, "cookie.json") {
+		t.Fatalf("CookiePath 错误: got %s", service.CookiePath)
 	}
 }

--- a/internal/server/app.go
+++ b/internal/server/app.go
@@ -11,21 +11,23 @@ import (
 )
 
 type App struct {
-	paths      RuntimePaths
-	cfg        ServerConfig
-	db         *sql.DB
-	http       *http.Server
-	closeLog   func()
-	cron       *cronScheduler
-	schedMu    sync.Mutex
-	schedWg    sync.WaitGroup
-	schedStop  chan struct{}
-	schedQueue chan scheduledRun
-	calibMu    sync.Mutex
-	calibWg    sync.WaitGroup
-	calibStop  chan struct{}
-	wpsMu      sync.RWMutex
-	wpsRuns    map[string]*wpsRuntimeSession
+	paths       RuntimePaths
+	cfg         ServerConfig
+	db          *sql.DB
+	http        *http.Server
+	closeLog    func()
+	cron        *cronScheduler
+	schedMu     sync.Mutex
+	schedWg     sync.WaitGroup
+	schedStop   chan struct{}
+	schedQueue  chan scheduledRun
+	calibMu     sync.Mutex
+	calibWg     sync.WaitGroup
+	calibStop   chan struct{}
+	runDedupeMu sync.Mutex
+	pendingRuns map[string]struct{}
+	wpsMu       sync.RWMutex
+	wpsRuns     map[string]*wpsRuntimeSession
 }
 
 func NewApp() (*App, error) {
@@ -68,11 +70,12 @@ func NewApp() (*App, error) {
 	}
 
 	app := &App{
-		paths:    paths,
-		cfg:      cfg,
-		db:       db,
-		closeLog: closeLog,
-		wpsRuns:  make(map[string]*wpsRuntimeSession),
+		paths:       paths,
+		cfg:         cfg,
+		db:          db,
+		closeLog:    closeLog,
+		pendingRuns: make(map[string]struct{}),
+		wpsRuns:     make(map[string]*wpsRuntimeSession),
 	}
 
 	app.http = &http.Server{

--- a/internal/server/clockin.go
+++ b/internal/server/clockin.go
@@ -330,8 +330,20 @@ func (a *App) handleClockinRuns(w http.ResponseWriter, r *http.Request) {
 // --- Core execution logic ---
 
 func (a *App) executeClockinRun(userID int64, triggerType string) (int64, string, string) {
+	return a.executeClockinRunForDate(userID, triggerType, "")
+}
+
+func (a *App) executeClockinRunForDate(userID int64, triggerType, runDate string) (int64, string, string) {
 	startedAt := time.Now().UTC()
-	runDate := startedAt.Format("20060102")
+	if strings.TrimSpace(runDate) == "" {
+		runDate = clockinRunDate(startedAt)
+	}
+
+	if isSchedulerTrigger(triggerType) && a.hasScheduledRunForDate(userID, runDate) {
+		message := "今日定时任务已执行，跳过重复打卡"
+		log.Printf("跳过重复定时打卡: user=%d trigger=%s run_date=%s", userID, triggerType, runDate)
+		return 0, "skipped", message
+	}
 
 	cfg, err := a.loadCoreConfigFromProfile(userID)
 	if err != nil {
@@ -367,6 +379,21 @@ func (a *App) executeClockinRun(userID int64, triggerType string) (int64, string
 	go a.sendUserNotifications(userID, evtType, title, result.Message)
 
 	return runID, finalStatus, finalMsg
+}
+
+func (a *App) hasScheduledRunForDate(userID int64, runDate string) bool {
+	var count int
+	err := a.db.QueryRow(`SELECT COUNT(1) FROM clockin_runs
+		WHERE user_id = ?
+		  AND run_date = ?
+		  AND status = 'success'
+		  AND trigger_type IN ('scheduler', 'scheduler_calibration', 'startup_recovery')`,
+		userID, runDate).Scan(&count)
+	if err != nil {
+		log.Printf("查询定时任务日期执行记录失败 user=%d run_date=%s: %v", userID, runDate, err)
+		return false
+	}
+	return count > 0
 }
 
 func (a *App) insertClockinRun(userID int64, triggerType, status, message string, startedAt time.Time, runDate string) (int64, string, string) {

--- a/internal/server/notification.go
+++ b/internal/server/notification.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"strings"
@@ -34,13 +35,13 @@ type userChannelDispatch struct {
 }
 
 type broadcastNotifyResult struct {
-	UsersWithChannels  int            `json:"users_with_channels"`
-	AttemptCount       int            `json:"attempt_count"`
-	SuccessCount       int            `json:"success_count"`
-	FailCount          int            `json:"fail_count"`
+	UsersWithChannels   int            `json:"users_with_channels"`
+	AttemptCount        int            `json:"attempt_count"`
+	SuccessCount        int            `json:"success_count"`
+	FailCount           int            `json:"fail_count"`
 	ChannelTypeAttempts map[string]int `json:"channel_type_attempts"`
-	ChannelTypeSuccess map[string]int `json:"channel_type_success"`
-	ChannelTypeFail    map[string]int `json:"channel_type_fail"`
+	ChannelTypeSuccess  map[string]int `json:"channel_type_success"`
+	ChannelTypeFail     map[string]int `json:"channel_type_fail"`
 }
 
 // --- Notification event types ---
@@ -335,15 +336,46 @@ func sendGotifyNotification(cfg gotifyNotifyConfig, title, body string) error {
 }
 
 func sendBarkNotification(cfg barkNotifyConfig, title, body string) error {
-	url := strings.TrimRight(cfg.ServerURL, "/") + "/" + cfg.DeviceKey + "/" + title + "/" + body
-	resp, err := httpNotifyClient.Get(url)
+	serverURL := strings.TrimRight(strings.TrimSpace(cfg.ServerURL), "/")
+	if serverURL == "" {
+		serverURL = "https://api.day.app"
+	}
+	deviceKey := strings.TrimSpace(cfg.DeviceKey)
+	if deviceKey == "" {
+		return fmt.Errorf("Bark Device Key 未配置")
+	}
+
+	payload, err := json.Marshal(map[string]string{
+		"device_key": deviceKey,
+		"title":      title,
+		"body":       body,
+	})
+	if err != nil {
+		return fmt.Errorf("序列化 Bark 请求失败: %w", err)
+	}
+
+	resp, err := httpNotifyClient.Post(serverURL+"/push", "application/json; charset=utf-8", strings.NewReader(string(payload)))
 	if err != nil {
 		return err
 	}
 	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 	if resp.StatusCode >= 400 {
-		return fmt.Errorf("Bark 返回状态码 %d", resp.StatusCode)
+		return fmt.Errorf("Bark 返回状态码 %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
 	}
+
+	var apiResp struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+	}
+	if len(respBody) > 0 && json.Unmarshal(respBody, &apiResp) == nil && apiResp.Code != 0 && apiResp.Code != 200 {
+		if strings.TrimSpace(apiResp.Message) == "" {
+			apiResp.Message = strings.TrimSpace(string(respBody))
+		}
+		return fmt.Errorf("Bark 返回错误 code=%d message=%s", apiResp.Code, apiResp.Message)
+	}
+
 	return nil
 }
 

--- a/internal/server/notification_test.go
+++ b/internal/server/notification_test.go
@@ -1,0 +1,39 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestSendBarkNotificationUsesPushJSON(t *testing.T) {
+	var gotPath, gotContentType string
+	var gotPayload map[string]string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotContentType = r.Header.Get("Content-Type")
+		if r.Method != http.MethodPost {
+			t.Fatalf("Bark 应使用 POST: got %s", r.Method)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&gotPayload); err != nil {
+			t.Fatalf("解析 Bark 请求体失败: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"code": 200, "message": "success"})
+	}))
+	defer ts.Close()
+
+	err := sendBarkNotification(barkNotifyConfig{ServerURL: ts.URL, DeviceKey: "dev/key"}, "标题/含斜杠", "内容 含空格/斜杠")
+	if err != nil {
+		t.Fatalf("发送 Bark 通知失败: %v", err)
+	}
+	if gotPath != "/push" {
+		t.Fatalf("Bark 请求路径错误: got %s", gotPath)
+	}
+	if gotContentType != "application/json; charset=utf-8" {
+		t.Fatalf("Bark Content-Type 错误: got %s", gotContentType)
+	}
+	if gotPayload["device_key"] != "dev/key" || gotPayload["title"] != "标题/含斜杠" || gotPayload["body"] != "内容 含空格/斜杠" {
+		t.Fatalf("Bark JSON 请求体错误: %#v", gotPayload)
+	}
+}

--- a/internal/server/scheduler.go
+++ b/internal/server/scheduler.go
@@ -25,6 +25,8 @@ type scheduledRun struct {
 	userID      int64
 	triggerType string
 	scheduledAt time.Time
+	runDate     string
+	dedupeKey   string
 }
 
 func newCronScheduler() *cronScheduler {
@@ -141,13 +143,19 @@ func (a *App) runSchedulerRunner(stop <-chan struct{}, queue <-chan scheduledRun
 		case <-stop:
 			return
 		case task := <-queue:
-			delay := time.Since(task.scheduledAt).Truncate(time.Second)
-			if delay < 0 {
-				delay = 0
-			}
-			log.Printf("调度执行器: 开始执行 user=%d trigger=%s delay=%s", task.userID, task.triggerType, delay)
-			runID, status, message := a.executeClockinRun(task.userID, task.triggerType)
-			log.Printf("调度执行器: 执行完成 user=%d run=%d status=%s message=%s", task.userID, runID, status, message)
+			func() {
+				if task.dedupeKey != "" {
+					defer a.releaseScheduledRun(task.dedupeKey)
+				}
+
+				delay := time.Since(task.scheduledAt).Truncate(time.Second)
+				if delay < 0 {
+					delay = 0
+				}
+				log.Printf("调度执行器: 开始执行 user=%d trigger=%s run_date=%s delay=%s", task.userID, task.triggerType, task.runDate, delay)
+				runID, status, message := a.executeClockinRunForDate(task.userID, task.triggerType, task.runDate)
+				log.Printf("调度执行器: 执行完成 user=%d run=%d status=%s message=%s", task.userID, runID, status, message)
+			}()
 		}
 	}
 }
@@ -163,10 +171,23 @@ func (a *App) submitScheduledRun(userID int64, triggerType string, scheduledAt t
 		return false
 	}
 
-	task := scheduledRun{userID: userID, triggerType: triggerType, scheduledAt: scheduledAt}
+	runDate := clockinRunDate(scheduledAt)
+	dedupeKey := ""
+	if isSchedulerTrigger(triggerType) {
+		dedupeKey = scheduledRunDedupeKey(userID, runDate)
+		if !a.reserveScheduledRun(dedupeKey) {
+			log.Printf("调度执行器: 已存在待执行/执行中的定时任务，跳过重复入队 user=%d trigger=%s run_date=%s", userID, triggerType, runDate)
+			return false
+		}
+	}
+
+	task := scheduledRun{userID: userID, triggerType: triggerType, scheduledAt: scheduledAt, runDate: runDate, dedupeKey: dedupeKey}
 
 	select {
 	case <-stop:
+		if dedupeKey != "" {
+			a.releaseScheduledRun(dedupeKey)
+		}
 		return false
 	case queue <- task:
 		return true
@@ -175,6 +196,9 @@ func (a *App) submitScheduledRun(userID int64, triggerType string, scheduledAt t
 		go func() {
 			select {
 			case <-stop:
+				if dedupeKey != "" {
+					a.releaseScheduledRun(dedupeKey)
+				}
 				return
 			case queue <- task:
 			}
@@ -367,6 +391,59 @@ func (a *App) hasRunForScheduleSlot(userID int64, scheduled, nextDue time.Time) 
 	return count > 0
 }
 
+func schedulerLocation() *time.Location {
+	loc, err := time.LoadLocation("Asia/Shanghai")
+	if err != nil {
+		return time.FixedZone("CST", 8*3600)
+	}
+	return loc
+}
+
+func clockinRunDate(t time.Time) string {
+	if t.IsZero() {
+		t = time.Now()
+	}
+	return t.In(schedulerLocation()).Format("20060102")
+}
+
+func isSchedulerTrigger(triggerType string) bool {
+	switch triggerType {
+	case "scheduler", "scheduler_calibration", "startup_recovery":
+		return true
+	default:
+		return false
+	}
+}
+
+func scheduledRunDedupeKey(userID int64, runDate string) string {
+	return fmt.Sprintf("%d:%s", userID, runDate)
+}
+
+func (a *App) reserveScheduledRun(key string) bool {
+	if key == "" {
+		return true
+	}
+	a.runDedupeMu.Lock()
+	defer a.runDedupeMu.Unlock()
+	if a.pendingRuns == nil {
+		a.pendingRuns = make(map[string]struct{})
+	}
+	if _, ok := a.pendingRuns[key]; ok {
+		return false
+	}
+	a.pendingRuns[key] = struct{}{}
+	return true
+}
+
+func (a *App) releaseScheduledRun(key string) {
+	if key == "" {
+		return
+	}
+	a.runDedupeMu.Lock()
+	defer a.runDedupeMu.Unlock()
+	delete(a.pendingRuns, key)
+}
+
 func (a *App) validateCronExpr(expr string) error {
 	loc, err := time.LoadLocation("Asia/Shanghai")
 	if err != nil {
@@ -457,10 +534,10 @@ func (a *App) recoverMissedJobs() {
 		nextTime := sched.Next(startOfToday.Add(-1 * time.Second))
 
 		if nextTime.In(loc).Format("20060102") == todayStr && nextTime.Before(now) {
-			log.Printf("恢复遗漏任务: 执行补签 user=%d scheduled=%s", j.userID, nextTime.In(loc).Format("15:04:05"))
-			runID, status, message := a.executeClockinRun(j.userID, "startup_recovery")
-			log.Printf("恢复遗漏任务: 完成 user=%d run=%d status=%s message=%s", j.userID, runID, status, message)
-			recoveredCount++
+			log.Printf("恢复遗漏任务: 入队补签 user=%d scheduled=%s", j.userID, nextTime.In(loc).Format("15:04:05"))
+			if a.submitScheduledRun(j.userID, "startup_recovery", nextTime) {
+				recoveredCount++
+			}
 		}
 	}
 

--- a/internal/server/scheduler_test.go
+++ b/internal/server/scheduler_test.go
@@ -1,0 +1,71 @@
+package server
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+)
+
+func TestSubmitScheduledRunDedupesSameUserAndRunDate(t *testing.T) {
+	a := &App{
+		pendingRuns: make(map[string]struct{}),
+		schedStop:   make(chan struct{}),
+		schedQueue:  make(chan scheduledRun, 2),
+	}
+	defer close(a.schedStop)
+
+	scheduledAt := time.Date(2026, 6, 8, 8, 0, 0, 0, schedulerLocation())
+	if !a.submitScheduledRun(42, "scheduler", scheduledAt) {
+		t.Fatal("首次定时任务应入队成功")
+	}
+	if a.submitScheduledRun(42, "scheduler_calibration", scheduledAt.Add(30*time.Second)) {
+		t.Fatal("同一用户同一打卡日期的补偿任务不应重复入队")
+	}
+
+	queued := <-a.schedQueue
+	if queued.runDate != "20260608" {
+		t.Fatalf("runDate 错误: got %s", queued.runDate)
+	}
+}
+
+func TestExecuteClockinRunForDateSkipsExistingScheduledRun(t *testing.T) {
+	db := newTestDB(t)
+	now := time.Date(2026, 6, 8, 1, 0, 0, 0, time.UTC)
+	_, err := db.Exec(`INSERT INTO users (id, email, password_hash, nickname, role, status, created_at, updated_at)
+		VALUES (1, 'u@example.com', 'hash', 'u', 'user', 'active', ?, ?)`, now, now)
+	if err != nil {
+		t.Fatalf("插入用户失败: %v", err)
+	}
+	_, err = db.Exec(`INSERT INTO clockin_runs (user_id, job_id, trigger_type, status, message, started_at, finished_at, run_date)
+		VALUES (1, NULL, 'scheduler', 'success', 'ok', ?, ?, '20260608')`, now, now)
+	if err != nil {
+		t.Fatalf("插入执行记录失败: %v", err)
+	}
+
+	a := &App{db: db}
+	runID, status, message := a.executeClockinRunForDate(1, "scheduler_calibration", "20260608")
+	if runID != 0 || status != "skipped" {
+		t.Fatalf("应跳过重复定时任务: runID=%d status=%s message=%s", runID, status, message)
+	}
+
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(1) FROM clockin_runs WHERE user_id = 1`).Scan(&count); err != nil {
+		t.Fatalf("查询执行记录失败: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("跳过重复任务不应插入新执行记录: got %d", count)
+	}
+}
+
+func newTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := openDatabase(t.TempDir() + "/apparition.db")
+	if err != nil {
+		t.Fatalf("打开测试数据库失败: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := migrateDatabase(db); err != nil {
+		t.Fatalf("迁移测试数据库失败: %v", err)
+	}
+	return db
+}


### PR DESCRIPTION
### Motivation
- Prevent duplicate clock-ins caused by overlapping triggers (cron, calibration, startup recovery) for the same user and date. 
- Ensure startup-recovery work is handled by the scheduler path so the same dedupe logic applies. 
- Fix Bark notification failures when using GET/path-based delivery with characters that break URL encoding. 

### Description
- Add scheduler deduplication by introducing `runDate` and `dedupeKey` to scheduled tasks and maintain an in-memory `pendingRuns` map with `reserveScheduledRun`/`releaseScheduledRun` guarded by `runDedupeMu`. 
- Stop enqueueing duplicate scheduled jobs by checking the dedupe key at `submitScheduledRun`, and release the dedupe entry when the run finishes or is aborted. 
- Route `startup_recovery` through the scheduler queue (use `submitScheduledRun`) instead of executing immediately to reuse dedupe logic. 
- Add a persistent guard in the execution path (`executeClockinRunForDate`) to skip runs when a successful scheduled run for the same `run_date` already exists and return a `skipped` status. 
- Change Bark delivery to use the JSON `/push` API with `POST`, validate `device_key`, support a default Bark server URL, and surface Bark API error codes/messages. 
- Add tests: `internal/server/scheduler_test.go` (queue dedupe and skip-on-existing-success) and `internal/server/notification_test.go` (Bark JSON payload), and make `internal/core/service_test.go` self-contained by writing a temp `config.json`. 

### Testing
- Ran `go test ./...` and all package tests passed; the added tests exercise scheduler dedupe and Bark JSON behavior. (success) 
- Ran `go build ./...` to verify the project compiles after changes. (success)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a262ddced94832f8f3a04211d0b5d5d)